### PR TITLE
Adding version strings for Cinnamon 2.2, 2.4 and 2.6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
  "uuid": "CinnaDockPlus@entelechy",
  "name": "CinnaDock Plus",
  "description": "Revamped CinnaDock with previews and native configuration and theming, for Cinnamon 1.8+",
- "cinnamon-version": [ "1.8", "1.9", "2.0", "2.1" ],
+ "cinnamon-version": [ "1.8", "1.9", "2.0", "2.1", "2.2", "2.4", "2.6" ],
  "url": "http://cinnamon-spices.linuxmint.com/extensions"
 }


### PR DESCRIPTION
Just adding missing version strings for newer version of Cinnamon.
