### PR TITLE
Adding version string for 2.8 branch of Cinnamon

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
  "uuid": "CinnaDockPlus@entelechy",
  "name": "CinnaDock Plus",
  "description": "Revamped CinnaDock with previews and native configuration and theming, for Cinnamon 1.8+",
- "cinnamon-version": [ "1.8", "1.9", "2.0", "2.1", "2.2", "2.4", "2.6" ],
+ "cinnamon-version": [ "1.8", "1.9", "2.0", "2.1", "2.2", "2.4", "2.6", "2.8" ],
  "url": "http://cinnamon-spices.linuxmint.com/extensions"
 }


### PR DESCRIPTION
Adding 2.8 version string to avoid warning for incompatible version when installing extension on Cinnamon 2.8.x.
